### PR TITLE
Redmine 3.x compatibility

### DIFF
--- a/app/views/wiki_templates/_body_bottom.html.erb
+++ b/app/views/wiki_templates/_body_bottom.html.erb
@@ -34,7 +34,13 @@
         "<%= url_for(:controller => 'wiki_templates', :action => :load) %>",
         $.param({id: selected_id}),
         function(data) {
-          $("#content_text").val(data);
+          var cke_frm = $('iframe.cke_wysiwyg_frame')[0];
+          if (cke_frm) {
+            var cke_body = $('body', cke_frm.contentWindow.document);
+            cke_body.html(data);
+          } else {
+            $("#content_text").val(data);
+          }
           notify_success("<%= l(:text_notify_success_of_loading) %>");
         },
         "text"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,7 @@ en:
   label_template_new: "New wiki template"
   label_choose_template: "Choose a template"
   label_load_template: "Load"
-  text_confirm_load_template: "the content will be replaced by template's text. sure?"
+  text_confirm_load_template: "the content will be replaced by template. sure?"
   text_notify_success_of_loading: "done."
   text_notify_failure_of_loading: "error: %{status}"
   permission_show_wiki_templates: "Use wiki templates"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   get 'projects/:project_id/wiki_templates/new', :to => 'wiki_templates#new'
   post 'projects/:project_id/wiki_templates/new', :to => 'wiki_templates#new'
-  post 'wiki_templates/preview', :to => 'wiki_templates#preview'
+  match 'wiki_templates/preview', :to => 'wiki_templates#preview', :via => [:post, :patch]
   get 'wiki_templates/load', :to => 'wiki_templates#load'
   resources :wiki_templates, :except => ['index', 'new', 'create']
 end

--- a/db/migrate/20130322052407_create_wiki_templates.rb
+++ b/db/migrate/20130322052407_create_wiki_templates.rb
@@ -6,7 +6,7 @@ class CreateWikiTemplates < ActiveRecord::Migration
       t.string     :name, :default => "", :null => false
       t.integer    :project_id, :default => 0, :null => false
       t.boolean    :is_public, :default => false, :null => false
-      t.timestamps
+      t.timestamps :null => false
     end
 
     add_index :wiki_templates, :project_id

--- a/init.rb
+++ b/init.rb
@@ -12,7 +12,7 @@ Redmine::Plugin.register :redmine_wiki_templates do
   description 'This plugin allow you choose a wiki template when you add a new wiki page.'
   version '0.2.0'
   url 'https://github.com/ucho/redmine_wiki_templates'
-  requires_redmine :version_or_higher => '2.2.0'
+  requires_redmine :version_or_higher => '3.0.0'
   project_module :wiki_templates do
     permission :show_wiki_templates, {:wiki_templates => [:load]}
     permission :manage_wiki_templates, {:wiki_templates => [:new, :edit, :update, :destroy, :preview]}


### PR DESCRIPTION
* Allow *patch* request when previewing a wiki template while editing (previewing works for new template). Ajax post (actually patch) request throws 404 due to hidden _method form field in the edit form.
* Rails 5 compatibility null flag in migration (timestamps default not null)

Note: latest version of plugin tested (and working!) on a Redmine 3.3.1 installation