### PR TITLE
Add cancel button on new/edit wiki template form page

### DIFF
--- a/app/views/wiki_templates/edit.html.erb
+++ b/app/views/wiki_templates/edit.html.erb
@@ -4,6 +4,7 @@
 <%= render :partial => 'form', :locals => {:f => f} %>
 <%= submit_tag l(:button_save) %>
 <%= preview_link({:controller => 'wiki_templates', :action => 'preview', :id => @wiki_template}, 'wiki_template_form') %>
+ | <%= link_to l(:button_cancel), back_url if back_url.present? %>
 <% end %>
 
 <div id="preview" class="wiki"></div>

--- a/app/views/wiki_templates/new.html.erb
+++ b/app/views/wiki_templates/new.html.erb
@@ -4,6 +4,7 @@
 <%= render :partial => 'form', :locals => {:f => f} %>
 <%= submit_tag l(:button_create) %>
 <%= preview_link({:controller => 'wiki_templates', :action => 'preview'}, 'wiki_template_form') %>
+ | <%= link_to l(:button_cancel), back_url if back_url.present? %>
 <% end %>
 
 <div id="preview" class="wiki"></div>


### PR DESCRIPTION
To avoid the use of the browser back button, I added a cancel button in the new/edit wiki template forms.