### PR TITLE
Fix Dutch (nl) language key. Replace "en" by "nl". Some leftover from c/p'ing

### DIFF
--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,5 +1,5 @@
 # Dutch strings go here for Rails i18n
-en:
+nl:
   project_module_wiki_templates: "Wiki sjablonen"
   label_template: "Sjabloon"
   label_template_new: "Nieuw wiki sjabloon"


### PR DESCRIPTION
Fix language key. Replace "en" by "nl". Some leftover from copy/pasting the English language file.